### PR TITLE
Change order of include / exclude

### DIFF
--- a/lib/rsyncwrapper.js
+++ b/lib/rsyncwrapper.js
@@ -52,15 +52,15 @@ exports.rsync = function (options,callback) {
         args.push("--verbose");
     }
 
-    if ( typeof options.exclude !== "undefined" && util.isArray(options.exclude) ) {
-        options.exclude.forEach(function (value,index) {
-            args.push("--exclude="+value);
-        });
-    }
-
     if ( typeof options.include !== "undefined" && util.isArray(options.include) ) {
         options.include.forEach(function (value,index) {
             args.push("--include="+value);
+        });
+    }
+
+    if ( typeof options.exclude !== "undefined" && util.isArray(options.exclude) ) {
+        options.exclude.forEach(function (value,index) {
+            args.push("--exclude="+value);
         });
     }
 


### PR DESCRIPTION
Now we can't use somethink like this:

```
rsync src dest --include=*/ --include=*.js --exclude=* -av
```

to sync only *.js" files, becouse order is first exclude, include.
