### PR TITLE
Use spawn with a shell to get best of both worlds

### DIFF
--- a/lib/rsyncwrapper.js
+++ b/lib/rsyncwrapper.js
@@ -114,9 +114,8 @@ exports.rsync = function (options,callback) {
         // see https://github.com/joyent/node/blob/937e2e351b2450cf1e9c4d8b3e1a4e2a2def58bb/lib/child_process.js#L589
         var child;
         if ('win32' === process.platform) {
-            child = spawn('cmd.exe', ['/s', '/c', '"' + cmd + '"']);
-            options = util._extend({}, options);
-            options.windowsVerbatimArguments = true;
+            child = spawn('cmd.exe', ['/s', '/c', '"' + cmd + '"'],
+                          {windowsVerbatimArguments:true} );
         }
         else {
             child = spawn('/bin/sh', ['-c', cmd]);


### PR DESCRIPTION
This should prevent a re-appearance of issue #1
while giving us shell expansion and globbing

npm test runs without errors
I haven't tested on Windows
