### PR TITLE
Fix for windows clients to read passphrase from stdin.

### DIFF
--- a/lib/rsyncwrapper.js
+++ b/lib/rsyncwrapper.js
@@ -115,7 +115,7 @@ exports.rsync = function (options,callback) {
         var child;
         if ('win32' === process.platform) {
             child = spawn('cmd.exe', ['/s', '/c', '"' + cmd + '"'],
-                          {windowsVerbatimArguments:true} );
+                          {windowsVerbatimArguments:true, stdio: [process.stdin, 'pipe', 'pipe']} );
         }
         else {
             child = spawn('/bin/sh', ['-c', cmd]);


### PR DESCRIPTION
To allow windows users to provide the passphrase via stdin, the process IO has to change:
- stdin: process.stdin (that is, the one from the shell)
- stdout: pipe to node.js (same as before)
- stderr: pipe to node.js (same as before)
