### PR TITLE
Added min-size option

### DIFF
--- a/lib/rsyncwrapper.js
+++ b/lib/rsyncwrapper.js
@@ -68,6 +68,10 @@ exports.rsync = function (options,callback) {
         args.push("--verbose");
     }
 
+    if ( options.minSize > 0 || typeof options.minSize === "number") {
+        args.push("--min-size=" + options.minSize);
+    }
+
     if ( typeof options.include !== "undefined" && util.isArray(options.include) ) {
         options.include.forEach(function (value,index) {
             args.push("--include="+value);


### PR DESCRIPTION
To prevent accidental overwriting of live files with zero byte files a `--min-size` argument can be added to the rsync command line. This change allows this to be submitted as `minSize` in the `options` object of the wrapper.