### PR TITLE
Adding rsync returned code into resulting object

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,6 +28,7 @@ module.exports = function(grunt) {
             all: {
                 src: [
                     "tests/package.js",
+                    "tests/errors.js",
                     "tests/single-copy.js",
                     "tests/multi-copy.js",
                     "tests/src-as-array.js",

--- a/lib/rsyncwrapper.js
+++ b/lib/rsyncwrapper.js
@@ -152,7 +152,12 @@ module.exports = function (options,callback) {
         });
 
         child.on("exit",function (code) {
-            callback(code===0?null:new Error("rsync exited with code "+code),stdout,stderr,cmd);
+            var err = null;
+            if (code !== 0) {
+                err = new Error("rsync exited with code " + code);
+                err.code = code;
+            }
+            callback(err,stdout,stderr,cmd);
         });
     } catch (err) {
         callback(err,null,null,cmd);

--- a/tests/errors.js
+++ b/tests/errors.js
@@ -1,0 +1,21 @@
+"use strict";
+
+var vows = require("vows");
+var assert = require("assert");
+var rsync = require("../lib/rsyncwrapper");
+
+exports.suite = vows.describe("Errors tests").addBatch({
+    "Call with a invalid args": {
+        topic: function() {
+            rsync({
+                src : "/tmp/not_found_folder_src",
+                dest: "/tmp/not_found_folder_dest",
+                args: ['--invalid-args'],
+            }, this.callback);
+        },
+        "throws an error and return a code": function(error, stdout) {
+            assert.isDefined(error);
+            assert.equal(error.code, 1);
+        }
+    }
+});

--- a/tests/package.js
+++ b/tests/package.js
@@ -7,21 +7,15 @@ var rsync = require("../lib/rsyncwrapper");
 
 exports.suite = vows.describe("Package tests").addBatch({
     "The RSyncWrapper package": {
-        topic: rsync,
+        topic: function() { return rsync },
         "is not null": function (rsync) {
             assert.isNotNull(rsync);
         },
         "exported module is a function": function (rsync) {
-            assert.isFunction(function () {});
+            assert.isFunction(rsync);
         },
         "throws an error when started without options": function (rsync) {
-            var error;
-            try {
-              rsync();
-            } catch (e) {
-              error = e;
-            }
-            assert.isDefined(error);
+            assert.throws(rsync, Error);
         }
     }
 });


### PR DESCRIPTION
The result code returned by `rsync` can be important in some cases. This PR adds this code into the resulting object in case of error, so that the current API is not broken.

Besides that, I've made a fix in the negative test cases from `package.js`. `topic` expects a function and when the `rsync` function was passed, `vows` called the function instead of returning it, which would be expected for the rest of the test.