### PR TITLE
Pipe all stdio in Windows. Fixes #50.

### DIFF
--- a/lib/rsyncwrapper.js
+++ b/lib/rsyncwrapper.js
@@ -165,8 +165,7 @@ module.exports = function(options, callback) {
     var child
     if (isWin) {
       child = spawn('cmd.exe', ['/s', '/c', '"' + cmd + '"'], {
-        windowsVerbatimArguments: true,
-        stdio: [process.stdin, 'pipe', 'pipe'],
+        windowsVerbatimArguments: true
       })
     } else {
       child = spawn('/bin/sh', ['-c', cmd])

--- a/lib/rsyncwrapper.js
+++ b/lib/rsyncwrapper.js
@@ -2,6 +2,7 @@
 
 var spawn = require('child_process').spawn
 var util = require('util')
+var tty = require('tty')
 
 var escapeSpaces = function(path) {
   if (typeof path === 'string') {
@@ -163,20 +164,28 @@ module.exports = function(options, callback) {
     // Launch cmd in a shell just like Node's child_process.exec() does:
     // see https://github.com/joyent/node/blob/937e2e351b2450cf1e9c4d8b3e1a4e2a2def58bb/lib/child_process.js#L589
     var child
+    var stdoutStream = null
+    var stderrStream = null
     if (isWin) {
+      stdoutStream = new tty.WriteStream(1)
+      stderrStream = new tty.WriteStream(2)
       child = spawn('cmd.exe', ['/s', '/c', '"' + cmd + '"'], {
-        windowsVerbatimArguments: true
+        windowsVerbatimArguments: true,
+        stdio: [process.stdin, stdoutStream, stderrStream]
       })
     } else {
       child = spawn('/bin/sh', ['-c', cmd])
     }
+    
+    if (stdoutStream === null) { stdoutStream = child.stdout; }
+    if (stderrStream === null) { stderrStream = child.stderr; } 
 
-    child.stdout.on('data', function(data) {
+    stdoutStream.on('data', function(data) {
       onStdout(data)
       stdout += data
     })
 
-    child.stderr.on('data', function(data) {
+    stderrStream.on('data', function(data) {
       onStderr(data)
       stderr += data
     })

--- a/lib/rsyncwrapper.js
+++ b/lib/rsyncwrapper.js
@@ -175,10 +175,9 @@ module.exports = function(options, callback) {
       })
     } else {
       child = spawn('/bin/sh', ['-c', cmd])
+      stdoutStream = child.stdout
+      stderrStream = child.stderr
     }
-    
-    if (stdoutStream === null) { stdoutStream = child.stdout; }
-    if (stderrStream === null) { stderrStream = child.stderr; } 
 
     stdoutStream.on('data', function(data) {
       onStdout(data)


### PR DESCRIPTION
I know it's been a while, but I finally got around to looking into why my terminal colors keep getting messed up. If I use `pipe` for all three channels (the default setting for `child_process.spawn`) the problem goes away.

I'm not sure why it was setup this way in the first place, so let me know if you see any issues with this change. I did a little light testing on Node 10 and 12 and everything worked great.

Fixes #50 