### PR TITLE
Include the error code on the error callback

### DIFF
--- a/lib/rsyncwrapper.d.ts
+++ b/lib/rsyncwrapper.d.ts
@@ -21,8 +21,12 @@ interface RsyncOptions {
     args?: Array<string>;
 }
 
+interface RsyncError extends Error {
+    code: number;
+}
+
 type RsyncCallback = (
-    error: Error | null,
+    error: RsyncError | null,
     stdout: string,
     stderr: string,
     cmd: string,

--- a/lib/rsyncwrapper.d.ts
+++ b/lib/rsyncwrapper.d.ts
@@ -22,7 +22,7 @@ interface RsyncOptions {
 }
 
 interface RsyncError extends Error {
-    code: number;
+    code?: number;
 }
 
 type RsyncCallback = (


### PR DESCRIPTION
The error callback receives an instance of Error, but with an additional property code, this fixes the definition.