### PR TITLE
Replace deprecated node util functions

### DIFF
--- a/lib/rsyncwrapper.js
+++ b/lib/rsyncwrapper.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var spawn = require('child_process').spawn
-var util = require('util')
 
 var escapeSpaces = function(path) {
   if (typeof path === 'string') {
@@ -29,7 +28,7 @@ var escapeSpacesInOptions = function(options) {
 
 module.exports = function(options, callback) {
   options = options || {}
-  options = util._extend({}, options)
+  options = Object.assign({}, options)
   options = escapeSpacesInOptions(options)
 
   var platform = options.platform || process.platform // Enable process.platform to be mocked in options for testing
@@ -105,20 +104,20 @@ module.exports = function(options, callback) {
 
   if (
     typeof options.excludeFirst !== 'undefined' &&
-    util.isArray(options.excludeFirst)
+    Array.isArray(options.excludeFirst)
   ) {
     options.excludeFirst.forEach(function(value, index) {
       args.push('--exclude=' + value)
     })
   }
 
-  if (typeof options.include !== 'undefined' && util.isArray(options.include)) {
+  if (typeof options.include !== 'undefined' && Array.isArray(options.include)) {
     options.include.forEach(function(value, index) {
       args.push('--include=' + value)
     })
   }
 
-  if (typeof options.exclude !== 'undefined' && util.isArray(options.exclude)) {
+  if (typeof options.exclude !== 'undefined' && Array.isArray(options.exclude)) {
     options.exclude.forEach(function(value, index) {
       args.push('--exclude=' + value)
     })
@@ -133,7 +132,7 @@ module.exports = function(options, callback) {
       break
   }
 
-  if (typeof options.args !== 'undefined' && util.isArray(options.args)) {
+  if (typeof options.args !== 'undefined' && Array.isArray(options.args)) {
     args = [...new Set([...args, ...options.args])]
   }
 


### PR DESCRIPTION
In recent node versions a couple of the util functions that we are currently using are deprecated. This simply replaces them with the recommended js built in functions.

We actually don't even need to require the util package anymore, so I removed it entirely. :)

Fixes #63